### PR TITLE
Use VITE_LIBRETRANSLATE_APIKEY variable for usage of libretranslate with an api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Here's a sample docker compose:
     environment:
       LANGUAGE_TOOL: https://your.languagetool.instance
       LIBRETRANSLATE: https://your.libretranslate.instance
+      VITE_LIBRETRANSLATE_APIKEY: <your-libretranslate-api-key>
       OLLAMA: https://your.ollama.instance
       OLLAMA_MODEL: model_name
       # pick one of: 'pole' | 'light' | 'dark' 

--- a/src/translate/API.ts
+++ b/src/translate/API.ts
@@ -14,7 +14,7 @@ export const API = () => {
         target: target.code,
         format: "text",
         alternatives: 3,
-        api_key: "",
+        api_key: import.meta.env.VITE_LIBRETRANSLATE_APIKEY,
       }),
       headers: { "Content-Type": "application/json" },
     }).then((data) => data.json());


### PR DESCRIPTION
Fixes #3, the variable has to be set before `npm run build`