### PR TITLE
feat: Add support for additional file types from LibreTranslate (Issue #18)

### DIFF
--- a/src/translate/Source.tsx
+++ b/src/translate/Source.tsx
@@ -13,16 +13,30 @@ const IconContainer = styled.div`
   z-index: 1;
 `;
 
+const supportedTextExtensions = ['txt', 'nfo', 'html', 'htm', 'xml', 'xhtml', 'md', 'srt'];
+const supportedBinaryExtensions = ['odt', 'docx', 'pptx', 'epub'];
+const allSupportedExtensions = [...supportedTextExtensions, ...supportedBinaryExtensions];
+
 const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
   const file = event?.target?.files && event.target.files[0];
   if (file) {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      //@ts-expect-error: result exists
-      actions.setQuestion(e.target.result);
-      snackActions.showSnack("File succesully read");
-    };
-    reader.readAsText(file);
+    const fileExtension = file.name.split('.').pop()?.toLowerCase();
+    const isTextFormat = supportedTextExtensions.includes(fileExtension || '');
+    const isBinaryFormat = supportedBinaryExtensions.includes(fileExtension || '');
+
+    if (isTextFormat) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        //@ts-expect-error: result exists
+        actions.setQuestion(e.target.result);
+        snackActions.showSnack("File successfully read");
+      };
+      reader.readAsText(file);
+    } else if (isBinaryFormat) {
+      snackActions.showSnack(`File format ${fileExtension} requires server-side processing`);
+    } else {
+      snackActions.showSnack("Unsupported file format");
+    }
   }
 };
 
@@ -64,7 +78,10 @@ export const Source = ({
             title={
               <span style={{ textAlign: "center" }}>
                 Upload file. <br /> supported file types:
-                .txt,.nfo,.html,.htm,.xml,.xhtml,.md
+                {allSupportedExtensions.map(ext => `.${ext}`).join(', ')}<br />
+                <span style={{ fontSize: '0.8em', color: '#666' }}>
+                  {supportedBinaryExtensions.map(ext => `.${ext}`).join(', ')} require server-side processing
+                </span>
               </span>
             }
           >
@@ -78,7 +95,7 @@ export const Source = ({
               <FileUploadOutlinedIcon fontSize="inherit" />
               <VisuallyHiddenInput
                 type="file"
-                accept=".txt,.nfo,.html,.htm,.xml,.xhtml,.md"
+                accept={allSupportedExtensions.map(ext => `.${ext}`).join(',')}
                 onChange={handleFileChange}
                 multiple={false}
               />


### PR DESCRIPTION

This pull request implements support for additional file types as requested in Issue #18.

## Changes Made

**File Modified**: `src/translate/Source.tsx`

### Key Improvements:

1. **Added support for new file extensions**:
   - Text-based: `.srt` (SubRip subtitle format)
   - Binary formats: `.odt`, `.docx`, `.pptx`, `.epub` (with informative messages)

2. **Refactored file type handling**:
   - Introduced extension variables for maintainability
   - Used consistent logic across UI and file processing

3. **Enhanced user experience**:
   - Updated tooltip to show all supported formats
   - Added clear messages for binary formats that require server-side processing

### Implementation Details:

- **Text formats** (including `.srt`): Read directly as plain text using FileReader API
- **Binary formats**: Show informative message about server-side processing requirement
- **Unsupported formats**: Clear error message

### Future Considerations:

For full support of binary formats, the application could be extended with:
1. Server-side processing to extract text from complex file formats
2. API endpoints to handle file uploads instead of just text content
3. Integration with libraries like `mammoth` (for .docx), `epub.js`, or `libreoffice` for text extraction

This implementation provides a solid foundation while maintaining backward compatibility and providing clear user feedback.
